### PR TITLE
PUC-491, Contribute Port interface to Sushy

### DIFF
--- a/sushy/main.py
+++ b/sushy/main.py
@@ -304,10 +304,17 @@ class Sushy(base.ResourceBase):
         if identity is None:
             chassis_collection = self.get_chassis_collection()
             listed_chassis = chassis_collection.get_members()
-            if len(listed_chassis) != 1:
+            invalid = True
+            errmsg = 'Chassis count is not exactly one'
+            if "Dell" in self.oem_vendors:
+                invalid = len(listed_chassis) > 2
+                errmsg = 'Chassis count does not match expected vendor type'
+            else:
+                invalid = len(listed_chassis) != 1
+            if invalid:
                 raise exceptions.UnknownDefaultError(
                     entity='Chassis',
-                    error='Chassis count is not exactly one')
+                    error=errmsg)
 
             identity = listed_chassis[0].path
 

--- a/sushy/resources/manager/manager.py
+++ b/sushy/resources/manager/manager.py
@@ -22,6 +22,7 @@ from sushy.resources import constants as res_cons
 from sushy.resources.manager import constants as mgr_cons
 from sushy.resources.manager import virtual_media
 from sushy.resources.system import ethernet_interface
+from sushy.resources.system.network import switch_connection
 from sushy import utils
 
 
@@ -251,6 +252,16 @@ class Manager(base.ResourceBase):
             self._conn,
             utils.get_sub_resource_path_by(self, "EthernetInterfaces"),
             redfish_version=self.redfish_version,
+            registries=self.registries, root=self.root)
+
+    @property
+    @utils.cache_it
+    def dell_switch_connections(self):
+        paths = utils.get_sub_resource_path_by(
+            self, ["Links", "Oem", "Dell", "DellSwitchConnectionCollection"],
+            is_collection=False)
+        return switch_connection.DellSwitchConnectionCollection(
+            self._conn, paths, redfish_version=self.redfish_version,
             registries=self.registries, root=self.root)
 
 

--- a/sushy/resources/system/network/adapter.py
+++ b/sushy/resources/system/network/adapter.py
@@ -17,6 +17,7 @@
 from sushy.resources import base
 from sushy.resources import common
 from sushy.resources.system.network import device_function
+from sushy.resources.system.network import network_port
 from sushy.resources.system.network import port
 from sushy import utils
 
@@ -77,9 +78,27 @@ class NetworkAdapter(base.ResourceBase):
         Here the actual refresh of the sub-resource happens, if stale.
         """
 
-        return port.NetworkPortCollection(
+        return network_port.NetworkPortCollection(
             self._conn,
             path=utils.get_sub_resource_path_by(self, "NetworkPorts"),
+            redfish_version=self.redfish_version,
+            registries=self.registries,
+            root=self.root
+        )
+
+    @property
+    @utils.cache_it
+    def ports(self):
+        """Property to reference `PortCollection` instance
+
+        It is set once when the first time it is queried. On refresh,
+        this property is marked as stale (greedy-refresh not done).
+        Here the actual refresh of the sub-resource happens, if stale.
+        """
+
+        return port.PortCollection(
+            self._conn,
+            path=utils.get_sub_resource_path_by(self, "Ports"),
             redfish_version=self.redfish_version,
             registries=self.registries,
             root=self.root

--- a/sushy/resources/system/network/device_function.py
+++ b/sushy/resources/system/network/device_function.py
@@ -17,7 +17,7 @@
 from sushy.resources import base
 from sushy.resources import common
 from sushy.resources.system.network import constants
-from sushy.resources.system.network import port
+from sushy.resources.system.network import network_port
 from sushy import utils
 
 
@@ -173,11 +173,10 @@ class NetworkDeviceFunction(base.ResourceBase):
         paths = utils.get_sub_resource_path_by(
             self, "AssignablePhysicalPorts", is_collection=True)
 
-        return [port.NetworkPort(self._conn, path,
-                                 redfish_version=self.redfish_version,
-                                 registries=self.registries,
-                                 root=self.root
-                                 )
+        return [network_port.NetworkPort(self._conn, path,
+                                         redfish_version=self.redfish_version,
+                                         registries=self.registries,
+                                         root=self.root)
                 for path in paths]
 
 

--- a/sushy/resources/system/network/network_port.py
+++ b/sushy/resources/system/network/network_port.py
@@ -1,0 +1,66 @@
+#    Copyright (c) 2021 Anexia Internetdienstleistungs GmbH
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# This is referred from Redfish standard schema.
+# https://redfish.dmtf.org/schemas/v1/NetworkPort.v1_2_1.json
+
+from sushy.resources import base
+from sushy.resources import common
+from sushy.resources.system.network import constants
+
+
+class NetworkPortCollection(base.ResourceCollectionBase):
+
+    @property
+    def _resource_type(self):
+        return NetworkPort
+
+
+class NetworkPort(base.ResourceBase):
+    associated_network_addresses = base.Field(
+        "AssociatedNetworkAddresses", adapter=list
+    )
+    """The array of configured network addresses that are associated."""
+
+    current_link_speed_mbps = base.Field(
+        "CurrentLinkSpeedMbps", adapter=int
+    )
+    """The network port current link speed."""
+
+    description = base.Field('Description')
+    """The network port description"""
+
+    flow_control_configuration = base.MappedField('FlowControlConfiguration',
+                                                  constants.FlowControl)
+    """The locally configured 802.3x flow control setting."""
+
+    flow_control_status = base.MappedField('FlowControlStatus',
+                                           constants.FlowControl)
+    """The 802.3x flow control behavior negotiated with the link partner"""
+
+    identity = base.Field('Id', required=True)
+    """The network port identity"""
+
+    link_status = base.MappedField('LinkStatus', constants.LinkStatus)
+    """The link status of the network port."""
+
+    name = base.Field(
+        "Name", required=True
+    )
+    """The network port name"""
+
+    physical_port_number = base.Field("PhysicalPortNumber", adapter=int)
+    """The physical port number label for this port."""
+
+    status = common.StatusField('Status')
+    """The network port status"""

--- a/sushy/resources/system/network/port.py
+++ b/sushy/resources/system/network/port.py
@@ -1,66 +1,81 @@
-#    Copyright (c) 2021 Anexia Internetdienstleistungs GmbH
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 
 # This is referred from Redfish standard schema.
-# https://redfish.dmtf.org/schemas/v1/NetworkPort.v1_2_1.json
+# https://redfish.dmtf.org/schemas/v1/Port.v1_8_0.json
+
 
 from sushy.resources import base
 from sushy.resources import common
 from sushy.resources.system.network import constants
 
 
-class NetworkPortCollection(base.ResourceCollectionBase):
+class LLDPReceiveField(base.CompositeField):
+    chassis_id = base.Field("ChassisId")
+    """chassis ID received from the remote partner across this link."""
 
-    @property
-    def _resource_type(self):
-        return NetworkPort
+    port_id = base.Field("PortId")
+    """A colon delimited string of hexadecimal octets identifying a port."""
 
 
-class NetworkPort(base.ResourceBase):
-    associated_network_addresses = base.Field(
-        "AssociatedNetworkAddresses", adapter=list
+class EthernetField(base.CompositeField):
+    associated_mac_addresses = base.Field(
+        "AssociatedMACAddresses", adapter=list
     )
-    """The array of configured network addresses that are associated."""
+    """The array of configured MAC addresses that are associated."""
 
-    current_link_speed_mbps = base.Field(
-        "CurrentLinkSpeedMbps", adapter=int
+    flow_control_configuration = base.MappedField(
+        "FlowControlConfiguration", constants.FlowControl
     )
-    """The network port current link speed."""
-
-    description = base.Field('Description')
-    """The network port description"""
-
-    flow_control_configuration = base.MappedField('FlowControlConfiguration',
-                                                  constants.FlowControl)
     """The locally configured 802.3x flow control setting."""
 
-    flow_control_status = base.MappedField('FlowControlStatus',
-                                           constants.FlowControl)
+    flow_control_status = base.MappedField(
+        "FlowControlStatus", constants.FlowControl
+    )
     """The 802.3x flow control behavior negotiated with the link partner"""
 
-    identity = base.Field('Id', required=True)
-    """The network port identity"""
+    lldp_receive = LLDPReceiveField("LLDPReceive")
+    """LLDP data being received on this link."""
 
-    link_status = base.MappedField('LinkStatus', constants.LinkStatus)
-    """The link status of the network port."""
 
-    name = base.Field(
-        "Name", required=True
-    )
-    """The network port name"""
+class Port(base.ResourceBase):
+    """This class adds the Port resource"""
 
-    physical_port_number = base.Field("PhysicalPortNumber", adapter=int)
-    """The physical port number label for this port."""
+    identity = base.Field("Id", required=True)
+    """The Port identity string"""
 
-    status = common.StatusField('Status')
-    """The network port status"""
+    name = base.Field("Name", required=True)
+    """The port name"""
+
+    current_speed_gbps = base.Field("CurrentSpeedGbps", adapter=int)
+    """The network port current link speed."""
+
+    description = base.Field("Description")
+    """The Port description"""
+
+    ethernet = EthernetField("Ethernet")
+    """The Ethernet-specific properties of the port."""
+
+    link_status = base.MappedField("LinkStatus", constants.LinkStatus)
+    """The link status of the port."""
+
+    port_id = base.Field("PortId")
+    """The physical port id label for this port."""
+
+    status = common.StatusField("Status")
+    """The port status"""
+
+
+class PortCollection(base.ResourceCollectionBase):
+    @property
+    def _resource_type(self):
+        return Port

--- a/sushy/resources/system/network/switch_connection.py
+++ b/sushy/resources/system/network/switch_connection.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# This is referred from Redfish standard schema.
+# https://redfish.dmtf.org/schemas/v1/SwitchCollection.json
+
+from sushy.resources import base
+
+
+class DellSwitchConnectionListField(base.ListField):
+
+    description = base.Field('Description')
+    """The description of the Dell switch connection instance resource"""
+
+    fqdd = base.Field('FQDD')
+    """The fully qualified device device descriptor of IDRAC or NIC"""
+
+    identity = base.Field('Id', required=True)
+    """The switch connection identity string"""
+
+    instance_id = base.Field('InstanceID', required=True)
+    """The switch connection instance identity string"""
+
+    name = base.Field('Name', required=True)
+    """The switch connection name"""
+
+    stale_data = base.Field('StaleData', required=True)
+    """The switch connection data status"""
+
+    switch_connection_id = base.Field('SwitchConnectionID', required=True)
+    """The switch connection device identity string"""
+
+    switch_port_connection_id = base.Field('SwitchPortConnectionID',
+                                           required=True)
+    """The switch connection port identity string"""
+
+
+class DellSwitchConnectionCollection(base.ResourceBase):
+
+    @property
+    def _resource_type(self):
+        return DellSwitchConnectionListField
+    description = base.Field('Description')
+    """The description of the Dell switch connection collection instance
+    resource"""
+
+    members = DellSwitchConnectionListField('Members', default=[])
+    """Uniquely identifies the member within the collection."""

--- a/sushy/tests/unit/json_samples/dell_manager.json
+++ b/sushy/tests/unit/json_samples/dell_manager.json
@@ -1,0 +1,357 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1",
+    "@odata.type": "#Manager.v1_17_0.Manager",
+    "Actions": {
+        "#Manager.Reset": {
+            "ResetType@Redfish.AllowableValues": ["GracefulRestart"],
+            "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset"
+        },
+        "#Manager.ResetToDefaults": {
+            "ResetType@Redfish.AllowableValues": [
+                "ResetAll",
+                "PreserveNetworkAndUsers"
+            ],
+            "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.ResetToDefaults"
+        },
+        "Oem": {
+            "#DellManager.ResetToDefaults": {
+                "ResetType@Redfish.AllowableValues": [
+                    "All",
+                    "Default",
+                    "ResetAllWithRootDefaults"
+                ],
+                "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/DellManager.ResetToDefaults"
+            },
+            "#DellManager.SetCustomDefaults": {
+                "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/DellManager.SetCustomDefaults"
+            },
+            "#OemManager.ExportSystemConfiguration": {
+                "ExportFormat@Redfish.AllowableValues": [
+                    "XML",
+                    "JSON"
+                ],
+                "ExportUse@Redfish.AllowableValues": [
+                    "Default",
+                    "Clone",
+                    "Replace"
+                ],
+                "IncludeInExport@Redfish.AllowableValues": [
+                    "Default",
+                    "IncludeReadOnly",
+                    "IncludePasswordHashValues",
+                    "IncludeCustomTelemetry"
+                ],
+                "ShareParameters": {
+                    "IgnoreCertificateWarning@Redfish.AllowableValues": [
+                        "Disabled",
+                        "Enabled"
+                    ],
+                    "ProxySupport@Redfish.AllowableValues": [
+                        "Disabled",
+                        "EnabledProxyDefault",
+                        "Enabled"
+                    ],
+                    "ProxyType@Redfish.AllowableValues": [
+                        "HTTP",
+                        "SOCKS4"
+                    ],
+                    "ShareType@Redfish.AllowableValues": [
+                        "LOCAL",
+                        "NFS",
+                        "CIFS",
+                        "HTTP",
+                        "HTTPS"
+                    ],
+                    "Target@Redfish.AllowableValues": [
+                        "ALL",
+                        "IDRAC",
+                        "BIOS",
+                        "NIC",
+                        "RAID",
+                        "FC",
+                        "InfiniBand",
+                        "SupportAssist",
+                        "EventFilters",
+                        "System",
+                        "LifecycleController",
+                        "AHCI",
+                        "PCIeSSD"
+                    ]
+                },
+                "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ExportSystemConfiguration"
+            },
+            "#OemManager.ImportSystemConfiguration": {
+                "ExecutionMode@Redfish.AllowableValues": ["Default", "DeployOnSledInsert", "InstantDeploy"],
+                "HostPowerState@Redfish.AllowableValues": [
+                    "On",
+                    "Off"
+                ],
+                "ImportSystemConfiguration@Redfish.AllowableValues": [
+                    "TimeToWait",
+                    "ImportBuffer"
+                ],
+                "ShareParameters": {
+                    "IgnoreCertificateWarning@Redfish.AllowableValues": [
+                        "Disabled",
+                        "Enabled"
+                    ],
+                    "ProxySupport@Redfish.AllowableValues": [
+                        "Disabled",
+                        "EnabledProxyDefault",
+                        "Enabled"
+                    ],
+                    "ProxyType@Redfish.AllowableValues": [
+                        "HTTP",
+                        "SOCKS4"
+                    ],
+                    "ShareType@Redfish.AllowableValues": [
+                        "LOCAL",
+                        "NFS",
+                        "CIFS",
+                        "HTTP",
+                        "HTTPS"
+                    ],
+                    "Target@Redfish.AllowableValues": [
+                        "ALL",
+                        "IDRAC",
+                        "BIOS",
+                        "NIC",
+                        "RAID",
+                        "FC",
+                        "InfiniBand",
+                        "SupportAssist",
+                        "EventFilters",
+                        "System",
+                        "LifecycleController",
+                        "AHCI",
+                        "PCIeSSD"
+                    ]
+                },
+                "ShutdownType@Redfish.AllowableValues": [
+                    "Graceful",
+                    "Forced",
+                    "NoReboot"
+                ],
+                "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfiguration"
+            },
+            "#OemManager.ImportSystemConfigurationPreview": {
+                "ImportSystemConfigurationPreview@Redfish.AllowableValues": [
+                    "ImportBuffer"
+                ],
+                "ShareParameters": {
+                    "IgnoreCertificateWarning@Redfish.AllowableValues": [
+                        "Disabled",
+                        "Enabled"
+                    ],
+                    "ProxySupport@Redfish.AllowableValues": [
+                        "Disabled",
+                        "EnabledProxyDefault",
+                        "Enabled"
+                    ],
+                    "ProxyType@Redfish.AllowableValues": [
+                        "HTTP",
+                        "SOCKS4"
+                    ],
+                    "ShareType@Redfish.AllowableValues": [
+                        "LOCAL",
+                        "NFS",
+                        "CIFS",
+                        "HTTP",
+                        "HTTPS"
+                    ],
+                    "Target@Redfish.AllowableValues": [
+                        "ALL"
+                    ]
+                },
+                "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfigurationPreview"
+            }
+        }
+    },
+    "CommandShell": {
+        "ConnectTypesSupported": [
+            "SSH",
+            "IPMI"
+        ],
+        "ConnectTypesSupported@odata.count": 2,
+        "MaxConcurrentSessions": 5,
+        "ServiceEnabled": true
+    },
+    "DateTime": "2024-09-24T05:12:36-05:00",
+    "DateTimeLocalOffset": "-05:00",
+    "Description": "BMC",
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/EthernetInterfaces"
+    },
+    "FirmwareVersion": "7.00.00.171",
+    "GraphicalConsole": {
+        "ConnectTypesSupported": ["KVMIP"],
+        "ConnectTypesSupported@odata.count": 1,
+        "MaxConcurrentSessions": 6,
+        "ServiceEnabled": true
+    },
+    "HostInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/HostInterfaces"
+    },
+    "Id": "iDRAC.Embedded.1",
+    "LastResetTime": "2024-09-11T15:03:31-05:00",
+    "Links": {
+        "ActiveSoftwareImage": {
+            "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-25227-7.00.00.171__iDRAC.Embedded.1-1"
+        },
+        "ManagerForChassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+            }
+        ],
+        "ManagerForChassis@odata.count": 1,
+        "ManagerForServers": [
+            {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+            }
+        ],
+        "ManagerForServers@odata.count": 1,
+        "ManagerInChassis": {
+            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+        },
+        "Oem": {
+            "Dell": {
+                "@odata.type": "#DellOem.v1_3_0.DellOemLinks",
+                "DellAttributes": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/iDRAC.Embedded.1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/System.Embedded.1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/LifecycleController.Embedded.1"
+                    }
+                ],
+                "DellAttributes@odata.count": 3,
+                "DellJobService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"
+                },
+                "DellLCService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+                },
+                "DellLicensableDeviceCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLicensableDevices"
+                },
+                "DellLicenseCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLicenses"
+                },
+                "DellLicenseManagementService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLicenseManagementService"
+                },
+                "DellOpaqueManagementDataCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellOpaqueManagementData"
+                },
+                "DellPersistentStorageService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellPersistentStorageService"
+                },
+                "DellSwitchConnectionCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections"
+                },
+                "DellSwitchConnectionService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSwitchConnectionService"
+                },
+                "DellSystemManagementService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSystemManagementService"
+                },
+                "DellSystemQuickSyncCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellSystemQuickSync"
+                },
+                "DellTimeService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellTimeService"
+                },
+                "DellUSBDeviceCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellUSBDevices"
+                },
+                "DelliDRACCardService": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+                },
+                "DellvFlashCollection": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellvFlash"
+                },
+                "Jobs": {
+                    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs"
+                }
+            }
+        },
+        "SoftwareImages": [
+            {
+                "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-25227-6.10.80.00__iDRAC.Embedded.1-1"
+            },
+            {
+                "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-25227-7.00.00.171__iDRAC.Embedded.1-1"
+            }
+        ],
+        "SoftwareImages@odata.count": 2
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/LogServices"
+    },
+    "ManagerType": "BMC",
+    "Model": "14G Monolithic",
+    "Name": "Manager",
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/NetworkProtocol"
+    },
+    "Oem": {
+        "Dell": {
+            "@odata.type": "#DellManager.v1_4_0.DellManager",
+            "DelliDRACCard": {
+                "@odata.context": "/redfish/v1/$metadata#DelliDRACCard.DelliDRACCard",
+                "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCard/iDRAC.Embedded.1-1_0x23_IDRACinfo",
+                "@odata.type": "#DelliDRACCard.v1_1_0.DelliDRACCard",
+                "Description": "An instance of DelliDRACCard will have data specific to the Integrated Dell Remote Access Controller (iDRAC) in the managed system.",
+                "IPMIVersion": "2.0",
+                "Id": "iDRAC.Embedded.1-1_0x23_IDRACinfo",
+                "LastSystemInventoryTime": "2024-09-20T00:57:20+00:00",
+                "LastUpdateTime": "2024-09-24T10:12:24+00:00",
+                "Name": "DelliDRACCard",
+                "URLString": "https://1.1.1.1:443"
+            },
+            "RemoteSystemLogs": {
+                "CA": {
+                    "Certificates": {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/RemoteSystemLogs/CA/Certificates"
+                    }
+                },
+                "HTTPS": {
+                    "Certificates": {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/RemoteSystemLogs/HTTPS/Certificates"
+                    },
+                    "SecureClientAuth": "Anonymous",
+                    "SecurePort": 6514,
+                    "SecureServers": [
+                        ""
+                    ],
+                    "SecureServers@odata.count": 1,
+                    "SecureSysLogEnable": "Disabled"
+                }
+            }
+        }
+    },
+    "PowerState": "On",
+    "Redundancy": [],
+    "Redundancy@odata.count": 0,
+    "SerialConsole": {
+        "ConnectTypesSupported": [],
+        "ConnectTypesSupported@odata.count": 0,
+        "MaxConcurrentSessions": 0,
+        "ServiceEnabled": false
+    },
+    "SerialInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/SerialInterfaces"
+    },
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "TimeZoneName": "CST6CDT",
+    "UUID": "324b474f-c0c2-5180-3110-00584c4c4544",
+    "VirtualMedia": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia"},
+    "VirtualMedia@Redfish.Deprecated": "Please migrate to use /redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+}

--- a/sushy/tests/unit/json_samples/dell_switch_connection.json
+++ b/sushy/tests/unit/json_samples/dell_switch_connection.json
@@ -1,0 +1,75 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#DellSwitchConnectionCollection.DellSwitchConnectionCollection",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections",
+    "@odata.type": "#DellSwitchConnectionCollection.DellSwitchConnectionCollection",
+    "Description": "A collection of DellSwitchConnection resource",
+    "Members": [
+        {
+            "@odata.context": "/redfish/v1/$metadata#DellSwitchConnection.DellSwitchConnection",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections/iDRAC.Embedded.1",
+            "@odata.type": "#DellSwitchConnection.v1_1_0.DellSwitchConnection",
+            "Description": "An instance of DellSwitchConnection will have the switch connection view information of all the ports.",
+            "FQDD": "iDRAC.Embedded.1",
+            "Id": "iDRAC.Embedded.1",
+            "InstanceID": "iDRAC.Embedded.1",
+            "Name": "DellSwitchConnection",
+            "StaleData": "NotStale",
+            "SwitchConnectionID": "aa:bb:cc:dd:ee:ff",
+            "SwitchPortConnectionID": "Fa0/13"
+        },
+        {
+            "@odata.context": "/redfish/v1/$metadata#DellSwitchConnection.DellSwitchConnection",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections/NIC.Integrated.1-1-1",
+            "@odata.type": "#DellSwitchConnection.v1_1_0.DellSwitchConnection",
+            "Description": "An instance of DellSwitchConnection will have the switch connection view information of all the ports.",
+            "FQDD": "NIC.Integrated.1-1-1",
+            "Id": "NIC.Integrated.1-1-1",
+            "InstanceID": "NIC.Integrated.1-1-1",
+            "Name": "DellSwitchConnection",
+            "StaleData": "NotStale",
+            "SwitchConnectionID": "Not Available",
+            "SwitchPortConnectionID": "Not Available"
+        },
+        {
+            "@odata.context": "/redfish/v1/$metadata#DellSwitchConnection.DellSwitchConnection",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections/NIC.Integrated.1-2-1",
+            "@odata.type": "#DellSwitchConnection.v1_1_0.DellSwitchConnection",
+            "Description": "An instance of DellSwitchConnection will have the switch connection view information of all the ports.",
+            "FQDD": "NIC.Integrated.1-2-1",
+            "Id": "NIC.Integrated.1-2-1",
+            "InstanceID": "NIC.Integrated.1-2-1",
+            "Name": "DellSwitchConnection",
+            "StaleData": "NotStale",
+            "SwitchConnectionID": "Not Available",
+            "SwitchPortConnectionID": "Not Available"
+        },
+        {
+            "@odata.context": "/redfish/v1/$metadata#DellSwitchConnection.DellSwitchConnection",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections/NIC.Integrated.1-3-1",
+            "@odata.type": "#DellSwitchConnection.v1_1_0.DellSwitchConnection",
+            "Description": "An instance of DellSwitchConnection will have the switch connection view information of all the ports.",
+            "FQDD": "NIC.Integrated.1-3-1",
+            "Id": "NIC.Integrated.1-3-1",
+            "InstanceID": "NIC.Integrated.1-3-1",
+            "Name": "DellSwitchConnection",
+            "StaleData": "NotStale",
+            "SwitchConnectionID": "Not Available",
+            "SwitchPortConnectionID": "Not Available"
+        },
+        {
+            "@odata.context": "/redfish/v1/$metadata#DellSwitchConnection.DellSwitchConnection",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections/NIC.Integrated.1-4-1",
+            "@odata.type": "#DellSwitchConnection.v1_1_0.DellSwitchConnection",
+            "Description": "An instance of DellSwitchConnection will have the switch connection view information of all the ports.",
+            "FQDD": "NIC.Integrated.1-4-1",
+            "Id": "NIC.Integrated.1-4-1",
+            "InstanceID": "NIC.Integrated.1-4-1",
+            "Name": "DellSwitchConnection",
+            "StaleData": "NotStale",
+            "SwitchConnectionID": "No Link",
+            "SwitchPortConnectionID": "No Link"
+        }
+    ],
+    "Members@odata.count": 5,
+    "Name": "DellSwitchConnectionCollection"
+}

--- a/sushy/tests/unit/json_samples/network_adapter.json
+++ b/sushy/tests/unit/json_samples/network_adapter.json
@@ -67,6 +67,10 @@
   "NetworkPorts": {
     "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/NetworkPorts"
   },
+  "NetworkPorts@Redfish.Deprecated": "Please migrate to use /redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/{NetworkAdaptersId}/Ports",
+  "Ports": {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/Ports"
+  },
   "PartNumber": "0R887V",
   "SerialNumber": "IL7403101N00ZJ",
   "Status": {

--- a/sushy/tests/unit/resources/system/network/test_adapter.py
+++ b/sushy/tests/unit/resources/system/network/test_adapter.py
@@ -17,7 +17,7 @@ from unittest import mock
 from sushy.resources import constants as res_cons
 from sushy.resources.system.network import adapter
 from sushy.resources.system.network import device_function
-from sushy.resources.system.network import port
+from sushy.resources.system.network import network_port
 from sushy.tests.unit import base
 
 
@@ -57,7 +57,7 @@ class NetworkAdapterTestCase(base.TestCase):
             self.conn.get.return_value.json.return_value = json.load(f)
         actual_network_ports = self.adapter.network_ports
         self.assertIsInstance(actual_network_ports,
-                              port.NetworkPortCollection)
+                              network_port.NetworkPortCollection)
         self.conn.get.return_value.json.assert_called_once_with()
 
     def test_network_ports_cached(self):
@@ -76,7 +76,7 @@ class NetworkAdapterTestCase(base.TestCase):
                   'json_samples/network_port_collection.json') as f:
             self.conn.get.return_value.json.return_value = json.load(f)
         ports = self.adapter.network_ports
-        self.assertIsInstance(ports, port.NetworkPortCollection)
+        self.assertIsInstance(ports, network_port.NetworkPortCollection)
 
         with open('sushy/tests/unit/'
                   'json_samples/network_adapter.json') as f:
@@ -91,7 +91,7 @@ class NetworkAdapterTestCase(base.TestCase):
                   'json_samples/network_port_collection.json') as f:
             self.conn.get.return_value.json.return_value = json.load(f)
         self.assertIsInstance(self.adapter.network_ports,
-                              port.NetworkPortCollection)
+                              network_port.NetworkPortCollection)
 
     def test_network_device_functions(self):
         self.conn.get.return_value.json.reset_mock()

--- a/sushy/tests/unit/resources/system/network/test_port.py
+++ b/sushy/tests/unit/resources/system/network/test_port.py
@@ -15,7 +15,7 @@ from unittest import mock
 
 from sushy.resources import constants as res_cons
 from sushy.resources.system.network import constants as net_cons
-from sushy.resources.system.network import port
+from sushy.resources.system.network import network_port
 from sushy.tests.unit import base
 
 
@@ -29,28 +29,30 @@ class NetworkPortTestCase(base.TestCase):
 
         self.conn.get.return_value.json.return_value = self.json_doc
 
-        self.port = port.NetworkPort(
+        self.network_port = network_port.NetworkPort(
             self.conn, '/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/'
                        '/NIC.Integrated.1/NetworkPorts/NIC.Integrated.1-1',
             redfish_version='1.0.2')
 
     def test__parse_attributes(self):
-        self.port._parse_attributes(self.json_doc)
-        self.assertEqual('1.0.2', self.port.redfish_version)
-        self.assertEqual('NIC.Integrated.1-1', self.port.identity)
-        self.assertEqual('Network Port View', self.port.name)
-        self.assertEqual('Network Port View', self.port.description)
-        self.assertEqual(res_cons.State.ENABLED, self.port.status.state)
-        self.assertEqual(res_cons.Health.OK, self.port.status.health)
-        self.assertEqual(res_cons.Health.OK, self.port.status.health_rollup)
+        self.network_port._parse_attributes(self.json_doc)
+        self.assertEqual('1.0.2', self.network_port.redfish_version)
+        self.assertEqual('NIC.Integrated.1-1', self.network_port.identity)
+        self.assertEqual('Network Port View', self.network_port.name)
+        self.assertEqual('Network Port View', self.network_port.description)
+        self.assertEqual(res_cons.State.ENABLED,
+                         self.network_port.status.state)
+        self.assertEqual(res_cons.Health.OK, self.network_port.status.health)
+        self.assertEqual(res_cons.Health.OK,
+                         self.network_port.status.health_rollup)
         self.assertEqual(['01:02:03:04:05:06'],
-                         self.port.associated_network_addresses)
-        self.assertEqual(10000, self.port.current_link_speed_mbps)
+                         self.network_port.associated_network_addresses)
+        self.assertEqual(10000, self.network_port.current_link_speed_mbps)
         self.assertEqual(net_cons.FlowControl.NONE,
-                         self.port.flow_control_configuration)
+                         self.network_port.flow_control_configuration)
         self.assertEqual(net_cons.FlowControl.NONE,
-                         self.port.flow_control_status)
-        self.assertEqual(net_cons.LinkStatus.UP, self.port.link_status)
+                         self.network_port.flow_control_status)
+        self.assertEqual(net_cons.LinkStatus.UP, self.network_port.link_status)
 
 
 class NetworkPortCollectionTestCase(base.TestCase):
@@ -64,7 +66,7 @@ class NetworkPortCollectionTestCase(base.TestCase):
 
         self.conn.get.return_value.json.return_value = self.json_doc
 
-        self.port_col = port.NetworkPortCollection(
+        self.port_col = network_port.NetworkPortCollection(
             self.conn, '/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/'
                        'NIC.Integrated.1/NetworkPorts',
             redfish_version='1.0.2')
@@ -79,7 +81,7 @@ class NetworkPortCollectionTestCase(base.TestCase):
         ),
             self.port_col.members_identities)
 
-    @mock.patch.object(port, 'NetworkPort', autospec=True)
+    @mock.patch.object(network_port, 'NetworkPort', autospec=True)
     def test_get_member(self, NetworkPort_mock):
         self.port_col.get_member(
             '/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/'
@@ -92,7 +94,7 @@ class NetworkPortCollectionTestCase(base.TestCase):
             redfish_version=self.port_col.redfish_version, registries=None,
             root=self.port_col.root)
 
-    @mock.patch.object(port, 'NetworkPort', autospec=True)
+    @mock.patch.object(network_port, 'NetworkPort', autospec=True)
     def test_get_members(self, NetworkPort_mock):
         members = self.port_col.get_members()
         NetworkPort_mock.assert_has_calls([

--- a/sushy/tests/unit/test_utils.py
+++ b/sushy/tests/unit/test_utils.py
@@ -20,6 +20,7 @@ from unittest import mock
 import sushy
 from sushy import exceptions
 from sushy.resources import base as resource_base
+from sushy.resources.manager import manager
 from sushy.resources.system import system
 from sushy.tests.unit import base
 from sushy import utils
@@ -82,6 +83,25 @@ class UtilsTestCase(base.TestCase):
         value = utils.get_sub_resource_path_by(self.sys_inst,
                                                subresource_path,
                                                is_collection=True)
+        self.assertEqual(expected_result, value)
+
+    def test_get_sub_resource_path_by_for_switch(self):
+        subresource_path = ["Links", "Oem", "Dell",
+                            "DellSwitchConnectionCollection"]
+        expected_result = ('/redfish/v1/Systems/System.Embedded.1'
+                           '/NetworkPorts/Oem/Dell/DellSwitchConnections')
+        with open('sushy/tests/unit/json_samples/dell_manager.json') as f:
+            manager_json = json.load(f)
+        with open('sushy/tests/unit/json_samples'
+                  '/dell_switch_connection.json') as f:
+            switch_json = json.load(f)
+        self.conn.get.return_value.json.return_value = manager_json
+        self.sys_inst = manager.Manager(self.conn,
+                                        '/redfish/v1/Manager/iDRAC.Embedded.1',
+                                        redfish_version='1.0.2')
+        self.conn.get.return_value.json.return_value = switch_json
+        value = utils.get_sub_resource_path_by(self.sys_inst,
+                                               subresource_path)
         self.assertEqual(expected_result, value)
 
     def test_get_sub_resource_path_by_fails(self):


### PR DESCRIPTION
The following change to be submitted:

- Correct the call for sushy/main.y:get_chassis() where on Dell chassis, there is more than one member where HP only has one. Example: 
```
    "Members": [
        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"},
        {"@odata.id": "/redfish/v1/Chassis/Enclosure.Internal.0-1:RAID.Slot.6-1"}
    ],
```
- Add call to GET /redfish/v1/Systems/System.Embedded.1/NetworkPorts/Oem/Dell/DellSwitchConnections
- Rename a file that reference to network_port (due to addition of Port Collection)
- Add Port Collection for the call to GET /redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/Ports
- Rename test that reference port to network port (reference in earlier bullet)
- Added dell_manager.json for getting DellSwitchConnection
- Update network_adapter.json to include the new "Port" collection information
- Added test to get DellSwitchConnection




